### PR TITLE
Redirect admins after login

### DIFF
--- a/src/app/login/kakao/callback/page.tsx
+++ b/src/app/login/kakao/callback/page.tsx
@@ -3,7 +3,8 @@
 
 import { useEffect, useRef, Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { kakaoLogin } from "@/features/auth/api/authApi";
+import { fetchUserInfo, kakaoLogin } from "@/features/auth/api/authApi";
+import { isAdminUser } from "@/utils/isAdminUser";
 
 function KakaoCallbackInner() {
   const router = useRouter();
@@ -34,6 +35,18 @@ function KakaoCallbackInner() {
         if (isNewUser) {
           router.replace("/signUp/kakao");
           return;
+        }
+
+        try {
+          const me = await fetchUserInfo();
+          localStorage.setItem("user", JSON.stringify(me));
+          if (isAdminUser(me)) {
+            router.replace("/admin");
+            return;
+          }
+        } catch (e) {
+          console.warn("⚠️ /auth/me 조회 실패:", e);
+          localStorage.removeItem("user");
         }
 
         router.replace("/");

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -9,12 +9,14 @@ import { AuthHeader, SubmitButton } from "@/components/authFormComponents";
 import Image from "next/image";
 import ConfirmModal from "@/components/confirmModal";
 import MobileMenu from "@/components/mobileMenu";
-import { SigninRequestDto } from "@/features/auth/types";
+import { SigninRequestDto, UserResponseDto } from "@/features/auth/types";
 import { useSignin } from "@/features/auth/hooks/useSignin";
 import api from "@/lib/apiClient"; // 서버에 /auth/signout 있으면 사용
 import { getKakaoAuthUrl } from "@/utils/getKakaoAuthUrl";
 import { useQueryClient } from "@tanstack/react-query";
 import { clearUserClientDataOnLogout } from "@/utils/logoutUtils";
+import { fetchUserInfo } from "@/features/auth/api/authApi";
+import { isAdminUser } from "@/utils/isAdminUser";
 
 const LoginPage: React.FC = () => {
   const queryClient = useQueryClient();
@@ -106,12 +108,20 @@ const LoginPage: React.FC = () => {
     const dto: SigninRequestDto = { id: input1.trim(), pw: input2 };
 
     signinMutate(dto, {
-      onSuccess: (userData) => {
+      onSuccess: async () => {
         const trimmedId = input1.trim();
 
-        // 1) 유저 정보 저장
+        // 1) 유저 정보 조회 & 저장
         //    accessToken은 useSignin 내부에서 localStorage에 저장된다고 가정
-        localStorage.setItem("user", JSON.stringify(userData));
+        let me: UserResponseDto | null = null;
+        try {
+          me = await fetchUserInfo();
+          localStorage.setItem("user", JSON.stringify(me));
+          queryClient.setQueryData(["auth", "me"], me);
+        } catch (e) {
+          console.warn("⚠️ /auth/me 조회 실패:", e);
+          localStorage.removeItem("user");
+        }
 
         // 2) 로그인 상태 유지 설정
         if (autoLogin) {
@@ -132,9 +142,8 @@ const LoginPage: React.FC = () => {
         // 4) 로그인 상태 갱신
         setIsLoggedIn(true);
 
-        // 5) 어드민 분기: mf-admin이면 관리자 페이지로 바로 이동
-        const idLower = trimmedId.toLowerCase();
-        if (idLower === "mf-admin") {
+        // 5) 어드민 분기: 계정 정보 확인 후 관리자면 이동
+        if (isAdminUser(me)) {
           router.replace("/admin");
           return;
         }

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -9,6 +9,7 @@ import {
   useSaveSearchKeyword,
 } from "@/features/search/hooks/useSearchHistory";
 import { useAuthStatus } from "@/features/auth/hooks/useAuthStatus";
+import { isAdminUser } from "@/utils/isAdminUser";
 
 interface HeaderProps {
   menuOpen: boolean;
@@ -22,7 +23,7 @@ export default function Header({ menuOpen, setMenuOpen }: HeaderProps) {
   const router = useRouter();
 
   const { isAuthenticated, user } = useAuthStatus();
-  const isAdmin = isAuthenticated && user?.id === "mf-admin";
+  const isAdmin = isAuthenticated && isAdminUser(user);
 
   const navItems = [
     { name: "Home", href: "/" },

--- a/src/components/mobileMenu.tsx
+++ b/src/components/mobileMenu.tsx
@@ -2,6 +2,7 @@ import { useRouter, usePathname } from "next/navigation";
 import { Dispatch, SetStateAction } from "react";
 import { useAuthStatus } from "@/features/auth/hooks/useAuthStatus";
 import Image from "next/image";
+import { isAdminUser } from "@/utils/isAdminUser";
 
 interface MobileMenuProps {
   menuOpen: boolean;
@@ -21,7 +22,7 @@ export const MobileMenu = ({ menuOpen, setMenuOpen }: MobileMenuProps) => {
   const router = useRouter();
   const pathname = usePathname();
   const { isAuthenticated, user } = useAuthStatus();
-  const isAdmin = isAuthenticated && user?.id === "mf-admin";
+  const isAdmin = isAuthenticated && isAdminUser(user);
 
   const handleClick = (path: string) => {
     router.push(path);

--- a/src/features/auth/api/authApi.ts
+++ b/src/features/auth/api/authApi.ts
@@ -25,6 +25,19 @@ const api = axios.create({
   headers: { "Content-Type": "application/json" },
 });
 
+const setAccessTokenCookie = (token: string) => {
+  if (typeof window === "undefined") return;
+
+  const secure = window.location.protocol === "https:" ? "; Secure" : "";
+  document.cookie =
+    [
+      `accessToken=${encodeURIComponent(token)}`,
+      "Path=/",
+      "SameSite=Lax",
+      "Max-Age=604800",
+    ].join("; ") + secure;
+};
+
 /** ✅ 인터셉터: 특정 요청에만 JWT 자동 첨부 + 로깅 */
 api.interceptors.request.use((config) => {
   const token =
@@ -109,6 +122,7 @@ export const signin = async (dto: SigninRequestDto): Promise<string> => {
   }
 
   localStorage.setItem("accessToken", token);
+  setAccessTokenCookie(token);
   return token;
 };
 
@@ -307,6 +321,7 @@ export const kakaoLogin = async (
 
   // 공통 로그인 로직과 맞추고 싶으면 여기서도 저장
   localStorage.setItem("accessToken", token);
+  setAccessTokenCookie(token);
 
   return { token, isNewUser };
 };

--- a/src/features/auth/types.ts
+++ b/src/features/auth/types.ts
@@ -35,6 +35,9 @@ export interface UserResponseDto {
   phone?: string;
   createdAt?: string; // 서버가 주면 사용, 아니면 무시
   profileImageUrl?: string;
+  // 관리자 판별용 (백엔드 응답에 맞춰 optional)
+  role?: string;
+  isAdmin?: boolean;
 }
 
 // 엔드포인트별 전용 페이로드

--- a/src/utils/isAdminUser.ts
+++ b/src/utils/isAdminUser.ts
@@ -1,0 +1,14 @@
+import { UserResponseDto } from "@/features/auth/types";
+
+export const isAdminUser = (user?: UserResponseDto | null) => {
+  if (!user) return false;
+
+  if (user.isAdmin === true) return true;
+
+  const role = user.role;
+  if (typeof role === "string" && role.toUpperCase().includes("ADMIN")) {
+    return true;
+  }
+
+  return user.id?.toLowerCase() === "mf-admin";
+};

--- a/src/utils/logoutUtils.ts
+++ b/src/utils/logoutUtils.ts
@@ -1,4 +1,10 @@
 export const clearUserClientDataOnLogout = () => {
+    if (typeof window !== "undefined") {
+        document.cookie =
+            "accessToken=; Path=/; Max-Age=0; SameSite=Lax" +
+            (window.location.protocol === "https:" ? "; Secure" : "");
+    }
+
     const KEYS_TO_CLEAR = [
         "accessToken",
         "user",


### PR DESCRIPTION
## Summary
- 관리자 계정 로그인 후 /admin으로 자동 이동되도록 처리
- 일반 사용자 흐름은 기존대로 유지

## Changes
- 로그인 성공 시 관리자 여부 체크 후 라우팅
- 관련 UI/네비 흐름 정리

## Testing
- 로컬에서 로그인/로그아웃 시나리오 수동 확인

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates post-login flow to fetch `/auth/me`, persist user state, and route admins to `/admin`, plus starts writing/clearing an `accessToken` cookie; issues here could cause mis-routing or session inconsistencies across storage/cookie auth.
> 
> **Overview**
> Adds a unified admin-detection helper (`isAdminUser`) and uses it across login flows and navigation to gate the Admin entry and redirect admins to `/admin` after both password and Kakao logins.
> 
> Changes login success handling to fetch `/auth/me` (instead of relying on prior returned data), store it in `localStorage`, seed React Query (`["auth","me"]`), and fall back safely if the fetch fails.
> 
> Persists the access token in a client cookie (in addition to `localStorage`) on `signin`/`kakaoLogin`, and clears that cookie on logout via `clearUserClientDataOnLogout`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5afd71d7ae2773663224563de03804392ea390cf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->